### PR TITLE
Deprecated chefspec matchers

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,10 +1,6 @@
 source "https://supermarket.getchef.com"
 
 metadata
-cookbook 'windows', '~> 1.31'
-cookbook 'powershell', '~> 3.0'
-cookbook 'iis', '~> 2.1'
-cookbook 'git', '~> 4.0'
 
 group :dev do
   cookbook 'min_config', path: 'spec/support/cookbooks/min_config'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,8 @@ description 'Installs/Configures Sitecore'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.4.0'
 
-depends 'windows', '~> 1.31'
+depends 'windows', '~> 1.36'
 depends 'powershell', '~> 3.0'
-depends 'iis', '~> 2.1'
+depends 'iis', '~> 4.1'
 depends 'openssl', '~> 1.1'
 depends 'git', '~> 4.0'


### PR DESCRIPTION
Fixes #1 by upgrading the iis cookbook from 2.x to 4.x, which no longer uses the deprecated method of declaring matchers.
